### PR TITLE
fix: action is Array or Dictionary can't be transformed

### DIFF
--- a/VirtualView/Creater/Setter/Expression/VVPropertyExpressionSetter.m
+++ b/VirtualView/Creater/Setter/Expression/VVPropertyExpressionSetter.m
@@ -130,6 +130,17 @@
     if (self.expression) {
         id objectValue = [self.expression resultWithObject:object];
         NSString *stringValue = [objectValue description];
+        
+        if ([objectValue isKindOfClass:[NSArray class]] || [objectValue isKindOfClass:[NSDictionary class]]) {
+            NSError *error = nil;
+            NSData *jsonData = [NSJSONSerialization dataWithJSONObject:objectValue options:NSJSONWritingPrettyPrinted error:&error];
+            NSString *jsonStr = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+            
+            if (!error && jsonStr) {
+                stringValue = jsonStr;
+            }
+        }
+        
         BOOL handled = NO;
         switch (self.valueType) {
             case TYPE_INT:


### PR DESCRIPTION
When action is Array or Dictionary, it's hard to transformed to NSArray or NSDictionary.

```
"items": [
     "action": {
        "id": 1,
        "name: "book name"
    },
    "type": 1"
]
```

the TangramBus's  event params get action is 
```
{
    id = 1;
    name = "book name";
}
``` 

While we want 
```
 {
        "id": 1,
        "name: "book name"
 }
```
